### PR TITLE
lint markdown syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,84 @@
-# Atomic_Subroutines--How_to_Encapsulate_Access_to_Them
+# Atomic Subroutines: How to Encapsulate Access to Them
+
 Fortran 2008 coarray programming with unordered execution segments (user-defined ordering) - Atomic Subroutines: Encapsulate access to atomic_define and atomic_ref
 
 # Overview
+
 This GitHub repository aims to show how to encapsulate access to the both Fortran 2008 atomic subroutines atomic_define and atomic_ref and thus, how to keep the parallel logic codes and syntax apart from the application's main logic codes.
-<br />
 
-Assume the following type definition and coarray declaration in a module:<br />
-!  Type Definition:<br />
-type, public :: ImageStatus_CA<br />
-&nbsp;&nbsp;private<br />
-&nbsp;&nbsp;integer(atomic_int_kind) :: m_atomic_intImageActivityFlag = 0<br />
-end type OOOPimsc_adtImageStatus_CA<br />
-!<br />
-! Coarray Declaration:<br />
-type (ImageStatus_CA), public, codimension[*], save :: ImageStatus_CA_1<br />
+Assume the following type definition and coarray declaration in a module:
 
-# How to Encapsulate Access to atomic_define:
-Encapsulating access to atomic_define is very straightforward: We can easily use a traditional style setter routine to do so. See the following code example:<br />
+```fortran
+type, public :: ImageStatus_CA
+private
+integer(atomic_int_kind) :: m_atomic_intImageActivityFlag = 0
+end type OOOPimsc_adtImageStatus_CA
 
-subroutine Set_atomic_intImageActivityFlag_CA (Object_CA, intImageActivityFlag, intImageNumber)<br />
-&nbsp;&nbsp;type (ImageStatus_CA), codimension[*], intent (inout) :: Object_CA<br />
-&nbsp;&nbsp;integer, intent (in) :: intImageActivityFlag<br />
-&nbsp;&nbsp;integer, intent (in) :: intImageNumber<br />
-&nbsp;&nbsp;!<br />
-&nbsp;&nbsp;call atomic_define (Object_CA[intImageNumber] % m_atomic_intImageActivityFlag, intImageActivityFlag)<br />
-&nbsp;&nbsp;!<br />
-end subroutine Set_atomic_intImageActivityFlag_CA<br />
+! Coarray Declaration:
+type (ImageStatus_CA), public, codimension[*], save :: ImageStatus_CA_1
+```
 
-# How to Encapsulate Access to atomic_ref:
+# How to Encapsulate Access to atomic_define
+
+Encapsulating access to atomic_define is very straightforward: We can easily use a traditional style setter routine to do so. See the following code example:
+
+```fortran
+subroutine Set_atomic_intImageActivityFlag_CA (Object_CA, intImageActivityFlag, intImageNumber)
+type (ImageStatus_CA), codimension[*], intent (inout) :: Object_CA
+integer, intent (in)                                  :: intImageActivityFlag
+integer, intent (in)                                  :: intImageNumber
+
+call atomic_define (Object_CA[intImageNumber] % m_atomic_intImageActivityFlag, intImageActivityFlag)
+
+end subroutine Set_atomic_intImageActivityFlag_CA
+```
+
+# How to Encapsulate Access to atomic_ref
+
 The first reflex to encapsulate access to atomic_ref may be to use a traditional style getter routine to do so. But the problem with atomic_ref is it's use in conjunction with a spin-wait loop synchronization and the required SYNC MEMORY statement after the atomic data transfer took place. Since we want to keep the call to atomic_ref apart form the spin-wait loop (also because of the spin-wait loop may not be part of the parallel logic code), and also want to keep the SYNC MEMORY statement at a place of it's own in the parallel logic code, we use a checker routine instead of a getter routine. See the following code example:
 
-logical function Check_atomic_intImageActivityFlag_CA (Object_CA, intCheckImageActivityFlag)<br />
-&nbsp;&nbsp;! in order to hide the sync memory statement herein, this Checker routine does not allow<br />
-&nbsp;&nbsp;! to access the member directly, but instead does only allow to check the atomic member<br />
-&nbsp;&nbsp;! for specific values (this Checker is intentioned for synchronizations)<br />
-&nbsp;&nbsp;type (ImageStatus_CA), codimension[*], intent (inout) :: Object_CA<br />
-&nbsp;&nbsp;integer, intent (in) :: intCheckImageActivityFlag<br />
-&nbsp;&nbsp;integer :: intImageActivityFlag<br />
-&nbsp;&nbsp;!<br />
-&nbsp;&nbsp;Check_atomic_intImageActivityFlag_CA = .false.<br />
-&nbsp;&nbsp;!<br />
-&nbsp;&nbsp;call atomic_ref (intImageActivityFlag, Object_CA % m_atomic_intImageActivityFlag)<br />
-&nbsp;&nbsp;if (intCheckImageActivityFlag == intImageActivityFlag) then<br />
-&nbsp;&nbsp;&nbsp;&nbsp;call subSyncMemory (Object_CA) ! executing sync memory<br />
-&nbsp;&nbsp;&nbsp;&nbsp;Check_atomic_intImageActivityFlag_CA = .true.<br />
-&nbsp;&nbsp;end if<br />
-&nbsp;&nbsp;!<br />
-end function Check_atomic_intImageActivityFlag_CA<br />
+```fortran
+logical function Check_atomic_intImageActivityFlag_CA (Object_CA, intCheckImageActivityFlag)
+! in order to hide the sync memory statement herein, this Checker routine does not allow
+! to access the member directly, but instead does only allow to check the atomic member
+! for specific values (this Checker is intentioned for synchronizations)
+type (ImageStatus_CA), codimension[*], intent (inout) :: Object_CA
+integer, intent (in)                                  :: intCheckImageActivityFlag
+integer                                               :: intImageActivityFlag
 
+Check_atomic_intImageActivityFlag_CA = .false.
 
-Then, to make use of this Checker routine, we could use a spin-wait loop from the main logic code (well, the following code snippet is rather part of the parallel logic code), something like this (the code uses an enumeration):<br />
+call atomic_ref (intImageActivityFlag, Object_CA % m_atomic_intImageActivityFlag)
 
-...<br />
-do ! check the ImageActivityFlag in local PGAS memory until it has<br />
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;! value Enum_ImageActivityFlag % ExecutionFinished<br />
-&nbsp;&nbsp;if (Check_atomic_intImageActivityFlag_CA (ImageStatus_CA_1, &<br />
-&nbsp;&nbsp;&nbsp;&nbsp;Enum_ImageActivityFlag % InitializeSegmentSynchronization)) then<br />
-&nbsp;&nbsp;&nbsp;&nbsp;! initialize the execution segment synchronization on the executing image<br />
-&nbsp;&nbsp;&nbsp;&nbsp;…<br />
-&nbsp;&nbsp;end if<br />
-&nbsp;&nbsp;!<br />
-&nbsp;&nbsp;if (Check_atomic_intImageActivityFlag_CA (ImageStatus_CA_1, &<br />
-&nbsp;&nbsp;&nbsp;&nbsp;Enum_ImageActivityFlag % ExecutionFinsihed)) then<br />
-&nbsp;&nbsp;&nbsp;&nbsp;! exit the loop<br />
-&nbsp;&nbsp;&nbsp;&nbsp;…<br />
-&nbsp;&nbsp;end if<br />
-&nbsp;&nbsp;!<br />
-end do<br />
-...<br />
+if (intCheckImageActivityFlag == intImageActivityFlag) then
+    call subSyncMemory (Object_CA) ! executing sync memory
+    Check_atomic_intImageActivityFlag_CA = .true.
+end if
+
+end function Check_atomic_intImageActivityFlag_CA
+```
+
+Then, to make use of this Checker routine, we could use a spin-wait loop from the main logic code (well, the following code snippet is rather part of the parallel logic code), something like this (the code uses an enumeration):
+
+```fortran
+do ! check the ImageActivityFlag in local PGAS memory until it has
+! value Enum_ImageActivityFlag % ExecutionFinished
+if (Check_atomic_intImageActivityFlag_CA (ImageStatus_CA_1, &
+    Enum_ImageActivityFlag % InitializeSegmentSynchronization)) then
+    ! initialize the execution segment synchronization on the executing image
+    …
+    ...
+end if
+
+if (Check_atomic_intImageActivityFlag_CA (ImageStatus_CA_1, &
+    Enum_ImageActivityFlag % ExecutionFinsihed)) then
+    ! exit the loop<br />
+    ...
+end if
+
+end do
+...
+```
 
 That way, the logic codes (parallel or main logic codes) remain without any direct call to atomic_ref and without any direct use of the SYNC MEMORY statement.
 


### PR DESCRIPTION
Dear Micheal,

Thank you for your great work on spreading CAF on our souls!

I have just linted the markdown syntax of this example: I do not why, you your README is polluted with a lot of **not** markdown elements and the fortran codes are not inserted into fortran-highlighting blocks.

I hope this makes more clear your example.

Cheers